### PR TITLE
exclude gh from sandbox

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -4,7 +4,8 @@
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
     "excludedCommands": [
-      "docker"
+      "docker",
+      "gh"
     ],
     "network": {
       "allowUnixSockets": [


### PR DESCRIPTION
add gh to sandbox.excludedCommands to allow GitHub CLI operations without restrictions