### PR TITLE
feat: add thinking control env vars to settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "MAX_THINKING_TOKENS": "128000"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## Summary
- Add CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING env var to settings
- Add MAX_THINKING_TOKENS env var to settings

## Test plan
- [ ] Verify env vars are picked up by Claude Code on startup
- [ ] Confirm adaptive thinking disabled when CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING is set
- [ ] Confirm MAX_THINKING_TOKENS respected during inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)