### PR TITLE
feat: add CLAUDE_CODE_EFFORT_LEVEL env var

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -3,7 +3,8 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
-    "MAX_THINKING_TOKENS": "128000"
+    "MAX_THINKING_TOKENS": "128000",
+    "CLAUDE_CODE_EFFORT_LEVEL": "high"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_CODE_EFFORT_LEVEL=high` to the env block in `settings.json`
- Ensures Claude Code runs with high effort level by default across all sessions

## Test plan
- [ ] Verify `CLAUDE_CODE_EFFORT_LEVEL` is present in `settings.json` env block
- [ ] Confirm Claude Code picks up the env var on next session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)