### PR TITLE
feat: langfuse tracing hook + /langfuse-trace skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ teams/
 
 # macOS
 .DS_Store
+
+# Local settings (contains secrets)
+settings.local.json
+
+# Langfuse hook venv
+hooks/.venv-langfuse/

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""
+Claude Code -> Langfuse hook
+
+"""
+
+import json
+import os
+import sys
+import time
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# --- Langfuse import (fail-open) ---
+try:
+    from langfuse import Langfuse, propagate_attributes
+except Exception:
+    sys.exit(0)
+
+# --- Paths ---
+STATE_DIR = Path.home() / ".claude" / "state"
+LOG_FILE = STATE_DIR / "langfuse_hook.log"
+STATE_FILE = STATE_DIR / "langfuse_state.json"
+LOCK_FILE = STATE_DIR / "langfuse_state.lock"
+
+DEBUG = os.environ.get("CC_LANGFUSE_DEBUG", "").lower() == "true"
+MAX_CHARS = int(os.environ.get("CC_LANGFUSE_MAX_CHARS", "20000"))
+
+# ----------------- Logging -----------------
+def _log(level: str, message: str) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(f"{ts} [{level}] {message}\n")
+    except Exception:
+        # Never block
+        pass
+
+def debug(msg: str) -> None:
+    if DEBUG:
+        _log("DEBUG", msg)
+
+def info(msg: str) -> None:
+    _log("INFO", msg)
+
+def warn(msg: str) -> None:
+    _log("WARN", msg)
+
+def error(msg: str) -> None:
+    _log("ERROR", msg)
+
+# ----------------- State locking (best-effort) -----------------
+class FileLock:
+    def __init__(self, path: Path, timeout_s: float = 2.0):
+        self.path = path
+        self.timeout_s = timeout_s
+        self._fh = None
+
+    def __enter__(self):
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.path, "a+", encoding="utf-8")
+        try:
+            import fcntl  # Unix only
+            deadline = time.time() + self.timeout_s
+            while True:
+                try:
+                    fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    if time.time() > deadline:
+                        break
+                    time.sleep(0.05)
+        except Exception:
+            # If locking isn't available, proceed without it.
+            pass
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            import fcntl
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        try:
+            self._fh.close()
+        except Exception:
+            pass
+
+def load_state() -> Dict[str, Any]:
+    try:
+        if not STATE_FILE.exists():
+            return {}
+        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+def save_state(state: Dict[str, Any]) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = STATE_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, STATE_FILE)
+    except Exception as e:
+        debug(f"save_state failed: {e}")
+
+def state_key(session_id: str, transcript_path: str) -> str:
+    # stable key even if session_id collides
+    raw = f"{session_id}::{transcript_path}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+# ----------------- Hook payload -----------------
+def read_hook_payload() -> Dict[str, Any]:
+    """
+    Claude Code hooks pass a JSON payload on stdin.
+    This script tolerates missing/empty stdin by returning {}.
+    """
+    try:
+        data = sys.stdin.read()
+        if not data.strip():
+            return {}
+        return json.loads(data)
+    except Exception:
+        return {}
+
+def extract_session_and_transcript(payload: Dict[str, Any]) -> Tuple[Optional[str], Optional[Path]]:
+    """
+    Tries a few plausible field names; exact keys can vary across hook types/versions.
+    Prefer structured values from stdin over heuristics.
+    """
+    session_id = (
+        payload.get("sessionId")
+        or payload.get("session_id")
+        or payload.get("session", {}).get("id")
+    )
+
+    transcript = (
+        payload.get("transcriptPath")
+        or payload.get("transcript_path")
+        or payload.get("transcript", {}).get("path")
+    )
+
+    if transcript:
+        try:
+            transcript_path = Path(transcript).expanduser().resolve()
+        except Exception:
+            transcript_path = None
+    else:
+        transcript_path = None
+
+    return session_id, transcript_path
+
+# ----------------- Transcript parsing helpers -----------------
+def get_content(msg: Dict[str, Any]) -> Any:
+    if not isinstance(msg, dict):
+        return None
+    if "message" in msg and isinstance(msg.get("message"), dict):
+        return msg["message"].get("content")
+    return msg.get("content")
+
+def get_role(msg: Dict[str, Any]) -> Optional[str]:
+    # Claude Code transcript lines commonly have type=user/assistant OR message.role
+    t = msg.get("type")
+    if t in ("user", "assistant"):
+        return t
+    m = msg.get("message")
+    if isinstance(m, dict):
+        r = m.get("role")
+        if r in ("user", "assistant"):
+            return r
+    return None
+
+def is_tool_result(msg: Dict[str, Any]) -> bool:
+    role = get_role(msg)
+    if role != "user":
+        return False
+    content = get_content(msg)
+    if isinstance(content, list):
+        return any(isinstance(x, dict) and x.get("type") == "tool_result" for x in content)
+    return False
+
+def iter_tool_results(content: Any) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    if isinstance(content, list):
+        for x in content:
+            if isinstance(x, dict) and x.get("type") == "tool_result":
+                out.append(x)
+    return out
+
+def iter_tool_uses(content: Any) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    if isinstance(content, list):
+        for x in content:
+            if isinstance(x, dict) and x.get("type") == "tool_use":
+                out.append(x)
+    return out
+
+def extract_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for x in content:
+            if isinstance(x, dict) and x.get("type") == "text":
+                parts.append(x.get("text", ""))
+            elif isinstance(x, str):
+                parts.append(x)
+        return "\n".join([p for p in parts if p])
+    return ""
+
+def truncate_text(s: str, max_chars: int = MAX_CHARS) -> Tuple[str, Dict[str, Any]]:
+    if s is None:
+        return "", {"truncated": False, "orig_len": 0}
+    orig_len = len(s)
+    if orig_len <= max_chars:
+        return s, {"truncated": False, "orig_len": orig_len}
+    head = s[:max_chars]
+    return head, {"truncated": True, "orig_len": orig_len, "kept_len": len(head), "sha256": hashlib.sha256(s.encode("utf-8")).hexdigest()}
+
+def get_model(msg: Dict[str, Any]) -> str:
+    m = msg.get("message")
+    if isinstance(m, dict):
+        return m.get("model") or "claude"
+    return "claude"
+
+def get_message_id(msg: Dict[str, Any]) -> Optional[str]:
+    m = msg.get("message")
+    if isinstance(m, dict):
+        mid = m.get("id")
+        if isinstance(mid, str) and mid:
+            return mid
+    return None
+
+# ----------------- Incremental reader -----------------
+@dataclass
+class SessionState:
+    offset: int = 0
+    buffer: str = ""
+    turn_count: int = 0
+
+def load_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
+    s = global_state.get(key, {})
+    return SessionState(
+        offset=int(s.get("offset", 0)),
+        buffer=str(s.get("buffer", "")),
+        turn_count=int(s.get("turn_count", 0)),
+    )
+
+def write_session_state(global_state: Dict[str, Any], key: str, ss: SessionState) -> None:
+    global_state[key] = {
+        "offset": ss.offset,
+        "buffer": ss.buffer,
+        "turn_count": ss.turn_count,
+        "updated": datetime.now(timezone.utc).isoformat(),
+    }
+
+def read_new_jsonl(transcript_path: Path, ss: SessionState) -> Tuple[List[Dict[str, Any]], SessionState]:
+    """
+    Reads only new bytes since ss.offset. Keeps ss.buffer for partial last line.
+    Returns parsed JSON lines (best-effort) and updated state.
+    """
+    if not transcript_path.exists():
+        return [], ss
+
+    try:
+        with open(transcript_path, "rb") as f:
+            f.seek(ss.offset)
+            chunk = f.read()
+            new_offset = f.tell()
+    except Exception as e:
+        debug(f"read_new_jsonl failed: {e}")
+        return [], ss
+
+    if not chunk:
+        return [], ss
+
+    try:
+        text = chunk.decode("utf-8", errors="replace")
+    except Exception:
+        text = chunk.decode(errors="replace")
+
+    combined = ss.buffer + text
+    lines = combined.split("\n")
+    # last element may be incomplete
+    ss.buffer = lines[-1]
+    ss.offset = new_offset
+
+    msgs: List[Dict[str, Any]] = []
+    for line in lines[:-1]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msgs.append(json.loads(line))
+        except Exception:
+            continue
+
+    return msgs, ss
+
+# ----------------- Turn assembly -----------------
+@dataclass
+class Turn:
+    user_msg: Dict[str, Any]
+    assistant_msgs: List[Dict[str, Any]]
+    tool_results_by_id: Dict[str, Any]
+
+def build_turns(messages: List[Dict[str, Any]]) -> List[Turn]:
+    """
+    Groups incremental transcript rows into turns:
+    user (non-tool-result) -> assistant messages -> (tool_result rows, possibly interleaved)
+    Uses:
+    - assistant message dedupe by message.id (latest row wins)
+    - tool results dedupe by tool_use_id (latest wins)
+    """
+    turns: List[Turn] = []
+    current_user: Optional[Dict[str, Any]] = None
+
+    # assistant messages for current turn:
+    assistant_order: List[str] = []             # message ids in order of first appearance (or synthetic)
+    assistant_latest: Dict[str, Dict[str, Any]] = {}  # id -> latest msg
+
+    tool_results_by_id: Dict[str, Any] = {}     # tool_use_id -> content
+
+    def flush_turn():
+        nonlocal current_user, assistant_order, assistant_latest, tool_results_by_id, turns
+        if current_user is None:
+            return
+        if not assistant_latest:
+            return
+        assistants = [assistant_latest[mid] for mid in assistant_order if mid in assistant_latest]
+        turns.append(Turn(user_msg=current_user, assistant_msgs=assistants, tool_results_by_id=dict(tool_results_by_id)))
+
+    for msg in messages:
+        role = get_role(msg)
+
+        # tool_result rows show up as role=user with content blocks of type tool_result
+        if is_tool_result(msg):
+            for tr in iter_tool_results(get_content(msg)):
+                tid = tr.get("tool_use_id")
+                if tid:
+                    tool_results_by_id[str(tid)] = tr.get("content")
+            continue
+
+        if role == "user":
+            # new user message -> finalize previous turn
+            flush_turn()
+
+            # start a new turn
+            current_user = msg
+            assistant_order = []
+            assistant_latest = {}
+            tool_results_by_id = {}
+            continue
+
+        if role == "assistant":
+            if current_user is None:
+                # ignore assistant rows until we see a user message
+                continue
+
+            mid = get_message_id(msg) or f"noid:{len(assistant_order)}"
+            if mid not in assistant_latest:
+                assistant_order.append(mid)
+            assistant_latest[mid] = msg
+            continue
+
+        # ignore unknown rows
+
+    # flush last
+    flush_turn()
+    return turns
+
+# ----------------- Langfuse emit -----------------
+def _tool_calls_from_assistants(assistant_msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    calls: List[Dict[str, Any]] = []
+    for am in assistant_msgs:
+        for tu in iter_tool_uses(get_content(am)):
+            tid = tu.get("id") or ""
+            calls.append({
+                "id": str(tid),
+                "name": tu.get("name") or "unknown",
+                "input": tu.get("input") if isinstance(tu.get("input"), (dict, list, str, int, float, bool)) else {},
+            })
+    return calls
+
+def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, transcript_path: Path) -> None:
+    user_text_raw = extract_text(get_content(turn.user_msg))
+    user_text, user_text_meta = truncate_text(user_text_raw)
+
+    last_assistant = turn.assistant_msgs[-1]
+    assistant_text_raw = extract_text(get_content(last_assistant))
+    assistant_text, assistant_text_meta = truncate_text(assistant_text_raw)
+
+    model = get_model(turn.assistant_msgs[0])
+
+    tool_calls = _tool_calls_from_assistants(turn.assistant_msgs)
+
+    # attach tool outputs
+    for c in tool_calls:
+        if c["id"] and c["id"] in turn.tool_results_by_id:
+            out_raw = turn.tool_results_by_id[c["id"]]
+            out_str = out_raw if isinstance(out_raw, str) else json.dumps(out_raw, ensure_ascii=False)
+            out_trunc, out_meta = truncate_text(out_str)
+            c["output"] = out_trunc
+            c["output_meta"] = out_meta
+        else:
+            c["output"] = None
+
+    with propagate_attributes(
+        session_id=session_id,
+        trace_name=f"Claude Code - Turn {turn_num}",
+        tags=["claude-code"],
+    ):
+        with langfuse.start_as_current_observation(
+            name=f"Claude Code - Turn {turn_num}",
+            input={"role": "user", "content": user_text},
+            metadata={
+                "source": "claude-code",
+                "session_id": session_id,
+                "turn_number": turn_num,
+                "transcript_path": str(transcript_path),
+                "user_text": user_text_meta,
+            },
+        ) as trace_span:
+            # LLM generation
+            with langfuse.start_as_current_observation(
+                name="Claude Response",
+                as_type="generation",
+                model=model,
+                input={"role": "user", "content": user_text},
+                output={"role": "assistant", "content": assistant_text},
+                metadata={
+                    "assistant_text": assistant_text_meta,
+                    "tool_count": len(tool_calls),
+                },
+            ):
+                pass
+
+            # Tool observations
+            for tc in tool_calls:
+                in_obj = tc["input"]
+                # truncate tool input if it's a large string payload
+                if isinstance(in_obj, str):
+                    in_obj, in_meta = truncate_text(in_obj)
+                else:
+                    in_meta = None
+
+                with langfuse.start_as_current_observation(
+                    name=f"Tool: {tc['name']}",
+                    as_type="tool",
+                    input=in_obj,
+                    metadata={
+                        "tool_name": tc["name"],
+                        "tool_id": tc["id"],
+                        "input_meta": in_meta,
+                        "output_meta": tc.get("output_meta"),
+                    },
+                ) as tool_obs:
+                    tool_obs.update(output=tc.get("output"))
+
+            trace_span.update(output={"role": "assistant", "content": assistant_text})
+
+# ----------------- Main -----------------
+def main() -> int:
+    start = time.time()
+    debug("Hook started")
+
+    if os.environ.get("TRACE_TO_LANGFUSE", "").lower() != "true":
+        return 0
+
+    public_key = os.environ.get("CC_LANGFUSE_PUBLIC_KEY") or os.environ.get("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.environ.get("CC_LANGFUSE_SECRET_KEY") or os.environ.get("LANGFUSE_SECRET_KEY")
+    host = os.environ.get("CC_LANGFUSE_BASE_URL") or os.environ.get("LANGFUSE_BASE_URL") or "https://cloud.langfuse.com"
+
+    if not public_key or not secret_key:
+        return 0
+
+    payload = read_hook_payload()
+    session_id, transcript_path = extract_session_and_transcript(payload)
+
+    if not session_id or not transcript_path:
+        # No structured payload; fail open (do not guess)
+        debug("Missing session_id or transcript_path from hook payload; exiting.")
+        return 0
+
+    if not transcript_path.exists():
+        debug(f"Transcript path does not exist: {transcript_path}")
+        return 0
+
+    try:
+        langfuse = Langfuse(public_key=public_key, secret_key=secret_key, host=host)
+    except Exception:
+        return 0
+
+    try:
+        with FileLock(LOCK_FILE):
+            state = load_state()
+            key = state_key(session_id, str(transcript_path))
+            ss = load_session_state(state, key)
+
+            msgs, ss = read_new_jsonl(transcript_path, ss)
+            if not msgs:
+                write_session_state(state, key, ss)
+                save_state(state)
+                return 0
+
+            turns = build_turns(msgs)
+            if not turns:
+                write_session_state(state, key, ss)
+                save_state(state)
+                return 0
+
+            # emit turns
+            emitted = 0
+            for t in turns:
+                emitted += 1
+                turn_num = ss.turn_count + emitted
+                try:
+                    emit_turn(langfuse, session_id, turn_num, t, transcript_path)
+                except Exception as e:
+                    debug(f"emit_turn failed: {e}")
+                    # continue emitting other turns
+
+            ss.turn_count += emitted
+            write_session_state(state, key, ss)
+            save_state(state)
+
+        try:
+            langfuse.flush()
+        except Exception:
+            pass
+
+        dur = time.time() - start
+        info(f"Processed {emitted} turns in {dur:.2f}s (session={session_id})")
+        return 0
+
+    except Exception as e:
+        debug(f"Unexpected failure: {e}")
+        return 0
+
+    finally:
+        try:
+            langfuse.shutdown()
+        except Exception:
+            pass
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/settings.json
+++ b/settings.json
@@ -4,7 +4,7 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "MAX_THINKING_TOKENS": "128000",
-    "CLAUDE_CODE_EFFORT_LEVEL": "high"
+    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh"
   },
   "permissions": {
     "allow": [
@@ -98,6 +98,16 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/.venv-langfuse/bin/python ~/.claude/hooks/langfuse_hook.py"
+          }
+        ]
+      }
+    ],
     "PermissionRequest": [],
     "Notification": [
       {
@@ -139,8 +149,10 @@
       "git:*"
     ]
   },
+  "effortLevel": "xhigh",
   "voiceEnabled": true,
   "feedbackSurveyState": {
     "lastShownTime": 1754059296016
-  }
+  },
+  "skipAutoPermissionPrompt": true
 }

--- a/skills/langfuse-trace/SKILL.md
+++ b/skills/langfuse-trace/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: langfuse-trace
+description: Enable/disable/inspect Langfuse tracing for the current project. Args - (none or `on`) enables, `off` disables, `status` reports state. Use when user wants to start or stop sending Claude Code session traces to Langfuse for this repo.
+---
+
+Dispatch based on the argument after `/langfuse-trace`:
+
+- no arg OR `on` → run `bash ~/.claude/skills/langfuse-trace/enable.sh`
+- `off` → run `bash ~/.claude/skills/langfuse-trace/disable.sh`
+- `status` → run `bash ~/.claude/skills/langfuse-trace/status.sh`
+- anything else → print: `Usage: /langfuse-trace [on|off|status]`
+
+Relay the script's stdout to the user verbatim. Do not add commentary, headers, or summaries.

--- a/skills/langfuse-trace/disable.sh
+++ b/skills/langfuse-trace/disable.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+if [[ "$REPO_ROOT" == "$HOME" || "$REPO_ROOT" == "$HOME/.claude" ]]; then
+  echo "Refusing to disable in $REPO_ROOT — run from a project repo, not \$HOME or ~/.claude."
+  exit 1
+fi
+
+SETTINGS_FILE="$REPO_ROOT/.claude/settings.local.json"
+
+if [[ ! -f "$SETTINGS_FILE" ]]; then
+  echo "Already disabled (no .claude/settings.local.json)."
+  exit 0
+fi
+
+CURRENT=$(jq -r '.env.TRACE_TO_LANGFUSE // ""' "$SETTINGS_FILE")
+if [[ "$CURRENT" != "true" ]]; then
+  echo "Already disabled."
+  exit 0
+fi
+
+TMP=$(mktemp)
+jq 'del(.env.TRACE_TO_LANGFUSE) | if (.env // {}) == {} then del(.env) else . end' "$SETTINGS_FILE" > "$TMP" && mv "$TMP" "$SETTINGS_FILE"
+
+echo "✓ Langfuse tracing disabled"

--- a/skills/langfuse-trace/enable.sh
+++ b/skills/langfuse-trace/enable.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+if [[ "$REPO_ROOT" == "$HOME" || "$REPO_ROOT" == "$HOME/.claude" ]]; then
+  echo "Refusing to enable in $REPO_ROOT — run from a project repo, not \$HOME or ~/.claude."
+  exit 1
+fi
+
+if ! bash "$SKILL_DIR/preflight.sh"; then
+  echo
+  echo "Global setup incomplete. Fix the above and retry."
+  exit 1
+fi
+
+mkdir -p "$REPO_ROOT/.claude"
+SETTINGS_FILE="$REPO_ROOT/.claude/settings.local.json"
+
+HOST=$(jq -r '.env.LANGFUSE_BASE_URL // "https://cloud.langfuse.com"' "$HOME/.claude/settings.local.json" 2>/dev/null || echo "https://cloud.langfuse.com")
+
+if [[ -f "$SETTINGS_FILE" ]]; then
+  CURRENT=$(jq -r '.env.TRACE_TO_LANGFUSE // ""' "$SETTINGS_FILE")
+  if [[ "$CURRENT" == "true" ]]; then
+    echo "Already enabled."
+    echo "  Host: $HOST"
+    exit 0
+  fi
+  TMP=$(mktemp)
+  jq '.env.TRACE_TO_LANGFUSE = "true"' "$SETTINGS_FILE" > "$TMP" && mv "$TMP" "$SETTINGS_FILE"
+else
+  printf '%s\n' '{"env":{"TRACE_TO_LANGFUSE":"true"}}' | jq '.' > "$SETTINGS_FILE"
+fi
+
+GITIGNORE="$REPO_ROOT/.gitignore"
+PATTERN=".claude/settings.local.json"
+if [[ -f "$GITIGNORE" ]]; then
+  if ! grep -Fxq "$PATTERN" "$GITIGNORE"; then
+    echo "$PATTERN" >> "$GITIGNORE"
+  fi
+else
+  echo "$PATTERN" > "$GITIGNORE"
+fi
+
+echo "✓ Langfuse tracing enabled → .claude/settings.local.json"
+echo "  Host: $HOST"
+echo "  Verify: run a turn, check ~/.claude/state/langfuse_hook.log"

--- a/skills/langfuse-trace/preflight.sh
+++ b/skills/langfuse-trace/preflight.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOOK_SCRIPT="$HOME/.claude/hooks/langfuse_hook.py"
+VENV_PY="$HOME/.claude/hooks/.venv-langfuse/bin/python"
+GLOBAL_SETTINGS="$HOME/.claude/settings.json"
+GLOBAL_LOCAL="$HOME/.claude/settings.local.json"
+
+if [[ ! -f "$HOOK_SCRIPT" ]]; then
+  echo "Missing: $HOOK_SCRIPT (hook script not installed)"
+  exit 1
+fi
+
+if [[ ! -x "$VENV_PY" ]]; then
+  echo "Missing: $VENV_PY (langfuse venv not installed)"
+  exit 1
+fi
+
+if ! "$VENV_PY" -c "import langfuse" 2>/dev/null; then
+  echo "langfuse package not importable in $VENV_PY"
+  exit 1
+fi
+
+if ! jq -e '.hooks.Stop[]?.hooks[]?.command | select(test("langfuse_hook\\.py"))' "$GLOBAL_SETTINGS" >/dev/null 2>&1; then
+  echo "Missing: Stop hook referencing langfuse_hook.py in $GLOBAL_SETTINGS"
+  exit 1
+fi
+
+if [[ ! -f "$GLOBAL_LOCAL" ]]; then
+  echo "Missing: $GLOBAL_LOCAL (global Langfuse keys not set)"
+  exit 1
+fi
+
+for k in LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY; do
+  val=$(jq -r ".env.${k} // \"\"" "$GLOBAL_LOCAL")
+  if [[ -z "$val" ]]; then
+    echo "Missing: env.${k} in $GLOBAL_LOCAL"
+    exit 1
+  fi
+  if [[ "$val" == *REPLACE_ME* ]]; then
+    echo "Placeholder value for env.${k} in $GLOBAL_LOCAL — paste real key"
+    exit 1
+  fi
+done
+
+exit 0

--- a/skills/langfuse-trace/status.sh
+++ b/skills/langfuse-trace/status.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+SETTINGS_FILE="$REPO_ROOT/.claude/settings.local.json"
+FLAG="OFF"
+if [[ -f "$SETTINGS_FILE" ]]; then
+  CURRENT=$(jq -r '.env.TRACE_TO_LANGFUSE // ""' "$SETTINGS_FILE")
+  [[ "$CURRENT" == "true" ]] && FLAG="ON"
+fi
+
+HOST=$(jq -r '.env.LANGFUSE_BASE_URL // "https://cloud.langfuse.com"' "$HOME/.claude/settings.local.json" 2>/dev/null || echo "https://cloud.langfuse.com")
+
+if PRE_OUT=$(bash "$SKILL_DIR/preflight.sh" 2>&1); then
+  PRE_OK=1
+else
+  PRE_OK=0
+fi
+
+echo "Tracing: $FLAG"
+if [[ "$PRE_OK" -eq 1 ]]; then
+  echo "  Global setup: ✓"
+else
+  FIRST=$(echo "$PRE_OUT" | head -n 1)
+  echo "  Global setup: ✗ ($FIRST)"
+fi
+echo "  Host: $HOST"
+echo "  Repo: $REPO_ROOT"


### PR DESCRIPTION
## Summary
- Global `Stop` hook streams Claude Code session turns (user prompt, assistant response, tool calls + results) to Langfuse Cloud.
- `/langfuse-trace` skill toggles tracing per project (`on` / `off` / `status`) with preflight checks and gitignore safety.
- Isolated `uv` venv for `langfuse` at `~/.claude/hooks/.venv-langfuse/` keeps deps out of system python.

## Test plan
- [ ] `~/.claude/hooks/.venv-langfuse/bin/python -c "import langfuse"` succeeds.
- [ ] Paste real keys into `~/.claude/settings.local.json`.
- [ ] In a project: `/langfuse-trace status` \u2192 `OFF`, `Global setup: \u2713`.
- [ ] `/langfuse-trace` \u2192 flag set, `.claude/settings.local.json` gitignored.
- [ ] Run a Claude Code turn; check `~/.claude/state/langfuse_hook.log` and Langfuse dashboard.
- [ ] `/langfuse-trace off` \u2192 flag cleanly removed.
- [ ] Negative: skill aborts when run from `\$HOME` / `~/.claude`.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)