### PR TITLE
feat(ralph): add beads tracker as alternative to GitHub issues

### DIFF
--- a/skills/prd-to-issues/SKILL.md
+++ b/skills/prd-to-issues/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: prd-to-issues
-description: Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.
+description: Break a PRD into independently-grabbable GitHub issues or beads child tasks using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.
 ---
 
 # PRD to Issues
 
-Break a PRD into independently-grabbable GitHub issues using vertical slices (tracer bullets).
+Break a PRD into independently-grabbable work items using vertical slices (tracer bullets). Supports either GitHub issues or beads child tasks under a parent epic.
 
 ## Process
 
+### 0. Ask the user which tracker to use
+
+Use AskUserQuestion with two options: **GitHub issues** (default) or **beads (`bd`)**. If the user already hands you a reference (e.g. `#42` or `<prefix>-1`), infer from that.
+
 ### 1. Locate the PRD
 
-Ask the user for the PRD GitHub issue number (or URL).
-
-If the PRD is not already in your context window, fetch it with `gh issue view <number>` (with comments).
+- **GitHub**: ask for the PRD issue number (or URL). If not in context, fetch with `gh issue view <number>` (with comments).
+- **Beads**: ask for the PRD epic ID. If not provided, auto-find with `bd list --type epic --status open` — use the single match or ask if ambiguous. Fetch with `bd show <epic-id>`.
 
 ### 2. Explore the codebase (optional)
 
@@ -23,7 +26,7 @@ If you have not already explored the codebase, do so to understand the current s
 
 Break the PRD into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
 
-Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
+Slices may be **HITL** or **AFK**. HITL slices require human interaction (architectural decision, design review). AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
 
 <vertical-slice-rules>
 - Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
@@ -49,15 +52,18 @@ Ask the user:
 
 Iterate until the user approves the breakdown.
 
-### 5. Create the GitHub issues
+### 5. Create the work items
+
+Create in dependency order (blockers first) so real IDs can be referenced in the "Blocked by" field.
+
+#### GitHub backend
 
 For each approved slice, create a GitHub issue using `gh issue create`. Use the issue body template below.
 
-Create issues in dependency order (blockers first) so you can reference real issue numbers in the "Blocked by" field.
+After creating each issue, ensure labels exist and apply them:
 
-After creating each issue, ensure labels exist and are applied:
-- Create labels if they don't exist `gh label create "status:blocked" --repo "owner/repo" --color "fbca04" --description "Blocked by dependency"` Note: --color takes hex without the # prefix`
-- Apply label and milestone to each issue `gh issue edit <issue-number> --repo "owner/repo" --milestone "<milestone-title>" --add-label "<label1>,<label2>"`
+- Create labels if missing: `gh label create "status:blocked" --repo "owner/repo" --color "fbca04" --description "Blocked by dependency"` (note: `--color` takes hex without the `#`).
+- Apply label and milestone: `gh issue edit <issue-number> --repo "owner/repo" --milestone "<milestone-title>" --add-label "<label1>,<label2>"`.
 
 Ask the user which milestone to assign, or create one if needed.
 
@@ -93,21 +99,41 @@ Reference by number from the parent PRD:
 
 Do NOT close or modify the parent PRD issue.
 
-### 6. Create supporting labels and Progress Log
+#### Beads backend
 
-After all task issues are created:
-
-1. Create the `in-progress` and `done` labels if they don't exist:
+For each approved slice, create a child task under the epic. Slugify any milestone name (lowercase, spaces → `-`) if scoping is used.
 
 ```bash
- gh label create "in-progress" --repo "owner/repo" --color "fbca04" --description "Work currently underway"
- gh label create "done" --repo "owner/repo" --color "0e8a16" --description "Work completed"
- gh label create "progress-log" --repo "owner/repo" --color "c5def5" --description "Progress log for autonomous coding loop"
+bd create "<slice title>" \
+  --type task \
+  --parent "<epic-id>" \
+  --description "<What-to-build markdown, including 'User stories addressed' and optional 'Parent PRD' reference>" \
+  --acceptance "$(cat <<'AC'
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+AC
+)" \
+  --deps blocks:<blocker-id-1>,blocks:<blocker-id-2> \
+  --label hitl \
+  --label milestone:<slug>    # only if scoping
 ```
 
-2. Create a Progress Log issue for the PRD:
+Swap `--label hitl` for `--label afk` on AFK slices. Omit `--deps` for unblocked slices. Omit the milestone label when the user isn't scoping.
+
+Do NOT pre-create labels — beads creates them lazily on first use.
+Do NOT modify or close the parent epic.
+
+### 6. Progress log setup
+
+#### GitHub backend
+
+Create `in-progress`, `done`, and `progress-log` labels if missing, then create a Progress Log issue:
 
 ```bash
+gh label create "in-progress" --repo "owner/repo" --color "fbca04" --description "Work currently underway"
+gh label create "done" --repo "owner/repo" --color "0e8a16" --description "Work completed"
+gh label create "progress-log" --repo "owner/repo" --color "c5def5" --description "Progress log for autonomous coding loop"
 
 gh issue create --repo "owner/repo" --title "[Progress Log] <PRD title>" --label "progress-log" --milestone "<milestone>" --body "$(cat <<'EOF'
 
@@ -125,3 +151,12 @@ gh issue create --repo "owner/repo" --title "[Progress Log] <PRD title>" --label
 EOF
 )"
 ```
+
+#### Beads backend
+
+No setup required. The progress log lives directly on the epic:
+
+- **Iteration summaries** → `bd comment <epic-id>` (timestamped stream, analogous to `gh issue comment`)
+- **Codebase Patterns** (evergreen) → `bd note <epic-id>` (appended to the epic's notes field, shown in `bd show`)
+
+Both streams are seeded on the first Ralph iteration — nothing to create up front.

--- a/skills/ralph-bootstrap/SKILL.md
+++ b/skills/ralph-bootstrap/SKILL.md
@@ -5,26 +5,37 @@ description: This skill should be used when the user asks to: "initialise Ralph"
 
 # Ralph Bootstrap
 
-Initialise Ralph Wiggum Autonomous Coding loop in current project.
+Initialise the Ralph Wiggum autonomous coding loop in the current project.
 
-## Prerequisites
+## 1. Ask the user which tracker Ralph should drive
 
-- `gh` CLI installed and authenticated
-- Github task issues created iva `/prd-to-issues` skill
+Use AskUserQuestion with two options: **GitHub issues** (default) or **beads (`bd`)**. The choice picks the prompt template that gets baked into the project.
 
-## Run the bootstrap script
+## 2. Prerequisites
+
+- `gh` CLI installed and authenticated (GitHub backend)
+- `bd` CLI installed and an initialised `.beads/` database (beads backend)
+- Task issues already created via `/prd-to-issues`
+
+## 3. Run the bootstrap script
+
+Pass the chosen backend as the first argument:
 
 ```bash
-~/.claude/skills/ralph-bootstrap/scripts/bootstrap.sh
+# GitHub
+~/.claude/skills/ralph-bootstrap/scripts/bootstrap.sh github
+
+# beads
+~/.claude/skills/ralph-bootstrap/scripts/bootstrap.sh beads
 ```
 
-This creates `scripts/ralph/` directory with prompt template.
+This creates `scripts/ralph/prompt.md` containing the tracker-specific instructions (with a `<!-- tracker: github -->` or `<!-- tracker: beads -->` marker on the first line so the ralph scripts can detect the backend).
 
 ## Files Created
 
 ```
 scripts/ralph/
-├── prompt.md # Instructions for Claude (reads tasks from Github issues)
+└── prompt.md # Instructions for Claude (tracker-specific)
 ```
 
 ## Usage After Bootstrap
@@ -39,7 +50,7 @@ afk-ralph 25
 
 ## Workflow
 
-1. `/write-a-prd` - create PRD as Github issue
-2. `/prd-to-issues` - break PRD into tasks issues + create Progress Log
-3. `/ralph-bootstrap` - set up local prompt in project
-4. `ralph-once` or `afk-ralph` - run autonomous coding loops
+1. `/write-a-prd` — create PRD as GitHub issue or beads epic
+2. `/prd-to-issues` — break PRD into task issues / child beads (progress log on GitHub, stream on epic in beads)
+3. `/ralph-bootstrap` — copy the matching prompt template into the project
+4. `ralph-once` or `afk-ralph` — run autonomous coding loops

--- a/skills/ralph-bootstrap/scripts/bootstrap.sh
+++ b/skills/ralph-bootstrap/scripts/bootstrap.sh
@@ -1,28 +1,38 @@
 #!/bin/bash
 # Ralph Wiggum Bootstrap Script
-# Creates scripts/ralph/ directory and copies prompt template
+# Creates scripts/ralph/ directory and copies the tracker-specific prompt template.
+#
+# Usage: bootstrap.sh [github|beads]
+# Default: github
 
 set -e
 
+BACKEND="${1:-github}"
 TEMPLATE_DIR="$HOME/Documents/Development/ralph-wiggum-claude/templates"
 TARGET_DIR="scripts/ralph"
 
-# Check template source exists
-if [ ! -d "$TEMPLATE_DIR" ]; then
-    echo "Error: Template directory not found: $TEMPLATE_DIR"
+case "$BACKEND" in
+    github|beads) ;;
+    *)
+        echo "Error: unknown backend '$BACKEND' (expected: github or beads)"
+        exit 1
+        ;;
+esac
+
+SOURCE_FILE="$TEMPLATE_DIR/prompt-$BACKEND.md"
+
+if [ ! -f "$SOURCE_FILE" ]; then
+    echo "Error: template not found: $SOURCE_FILE"
     exit 1
 fi
 
-# Create target directory
 mkdir -p "$TARGET_DIR"
+cp "$SOURCE_FILE" "$TARGET_DIR/prompt.md"
 
-# Copy template
-cp "$TEMPLATE_DIR/prompt.md" "$TARGET_DIR/"
-
-echo "Ralph template copied to $TARGET_DIR/"
+echo "Ralph template ($BACKEND) copied to $TARGET_DIR/prompt.md"
 echo ""
 echo "Files created:"
-echo "  - $TARGET_DIR/prompt.md (Claude instructions)"
+echo "  - $TARGET_DIR/prompt.md (Claude instructions, tracker=$BACKEND)"
 echo ""
 echo "Next steps:"
 echo "  1. Run: ralph-once (single iteration)"

--- a/skills/write-a-prd/SKILL.md
+++ b/skills/write-a-prd/SKILL.md
@@ -1,23 +1,45 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description: Create a PRD through user interview, codebase exploration, and module design, then submit it as a GitHub issue or a beads epic. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
 ---
 
 This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
 
-1. Ask the user for a long, detailed description of the problem they want to solve and any potential ideas for solutions.
+## 0. Ask the user which tracker to use
 
-2. Explore the repo to verify their assertions and understand the current state of the codebase.
+Use AskUserQuestion with two options: **GitHub issues** (default) or **beads (`bd`)**. Record the choice — the submission step in section 6 branches on it.
 
-3. Interview the user relentlessly about every aspect of this plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+If **beads** is chosen and `.beads/` does not exist in the current working directory, run:
 
-4. Sketch out the major modules you will need to build or modify to complete the implementation. Actively look for opportunities to extract deep modules that can be tested in isolation.
+```bash
+bd init --prefix "$(basename "$PWD")"
+```
+
+This uses the default (non-stealth) mode so `.beads/` is tracked with the repo.
+
+## 1. Gather the problem
+
+Ask the user for a long, detailed description of the problem they want to solve and any potential ideas for solutions.
+
+## 2. Explore the repo
+
+Verify their assertions and understand the current state of the codebase.
+
+## 3. Interview relentlessly
+
+Interview the user about every aspect of this plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+
+## 4. Sketch modules
+
+Sketch out the major modules you will need to build or modify to complete the implementation. Actively look for opportunities to extract deep modules that can be tested in isolation.
 
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
 Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
 
-5. Once you have a complete understanding of the problem and solution, use the template below to write the PRD. The PRD should be submitted as a GitHub issue.
+## 5. Draft the PRD
+
+Use the template below.
 
 <prd-template>
 
@@ -72,3 +94,27 @@ A description of the things that are out of scope for this PRD.
 Any further notes about the feature.
 
 </prd-template>
+
+## 6. Submit the PRD
+
+### GitHub backend
+
+Create the PRD as a GitHub issue with `gh issue create`. Use the full PRD markdown as the body.
+
+### Beads backend
+
+Write the full PRD markdown to a tempfile and create it as an open epic:
+
+```bash
+TMP=$(mktemp)
+cat > "$TMP" <<'PRD'
+<full PRD markdown from step 5>
+PRD
+
+bd create "<PRD title>" \
+  --type epic \
+  --body-file "$TMP" \
+  --priority 2
+```
+
+Capture the resulting epic ID (e.g. `<prefix>-1`) and report it to the user — they'll pass it to `/prd-to-issues` next.


### PR DESCRIPTION
## Summary

- `/write-a-prd`, `/prd-to-issues`, `/ralph-bootstrap` now ask user to pick **GitHub** or **beads** at step 0
- Beads path: `bd init` on first run, PRD as epic via `bd create --type epic`, child tasks via `bd create --type task --parent <epic-id>` with acceptance criteria, deps, labels, and optional milestone
- GitHub path is **unchanged** — beads support is purely additive

## Test plan

- [ ] Run `/write-a-prd` and select `beads` — verify `bd init` runs if `.beads/` missing and PRD created as open epic
- [ ] Run `/write-a-prd` and select `github` — verify existing GitHub issue flow works unchanged
- [ ] Run `/prd-to-issues` with beads epic — verify child tasks created with `--parent`, labels (`hitl`/`afk`), deps, and optional milestone
- [ ] Run `/prd-to-issues` with github — verify GitHub issues flow unchanged
- [ ] Run `/ralph-bootstrap` and select `beads` — verify `bootstrap.sh beads` copies `templates/prompt-beads.md` → `scripts/ralph/prompt.md`
- [ ] Run `/ralph-bootstrap` and select `github` — verify `bootstrap.sh github` copies `templates/prompt-github.md`
- [ ] `bash -n skills/ralph-bootstrap/scripts/bootstrap.sh` passes with no errors