### PR TITLE
feat: excalidraw skill + ralph notify.env + settings updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
-<!-- # - When reporting information to me, be extremely concise and sacrifice grammar for the sake of concision.
-# - In all interactions and commit messages, be extremely concise and sacrifice grammar for the sake of concision. -->
+# General
+
+- When reporting information to me, be concise without omitting important details, but no walls of text!
+- In all interactions and commit messages, be extremely concise and sacrifice grammar for the sake of concision.
 
 ## PR Comments
 
@@ -17,14 +19,13 @@
 ## Plans
 
 - At the end of each plan, give me a list of unresolved questions to answer, if any
-<!-- # - When you generate a plan and  present it to me in the terminal print only a concise summary + headings, sacrifice grammar for the sake of concision. -->
+- When you generate a plan and present it to me in the terminal print only a concise summary + headings.
 - When you are done implementing the plan clean up after yourself, when the plan is not needed delete it from ~/.claude/plans
+- NEVER accept your internal training knowledge when the user asks you to do a research first. If the search if blocked by sandbox, stop and tell the user to enable the websearch or ask permissions to run the web search outside sandbox.
 
 ## Custom Agents
 
 You can use the following agents:
-
-<!-- # - senior-python-dev - use it for ALL  Python applications -->
 
 - git-ops - use it for ALL git operations, following the Git preferences described above
 

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "cleanupPeriodDays": 9999,
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
@@ -132,8 +133,18 @@
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
-    "rust-analyzer-lsp@claude-plugins-official": true
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "beads@beads-marketplace": true
   },
+  "extraKnownMarketplaces": {
+    "beads-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "steveyegge/beads"
+      }
+    }
+  },
+  "viewMode": "verbose",
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
@@ -149,13 +160,16 @@
       "git:*"
     ]
   },
-  "effortLevel": "xhigh",
+  "advisorModel": "opus",
+  "showClearContextOnPlanAccept": true,
   "verbose": true,
   "preferredNotifChannel": "ghostty",
   "autoCompactEnabled": false,
   "teammateMode": "auto",
+  "useAutoModeDuringPlan": true,
   "voiceEnabled": true,
   "feedbackSurveyState": {
     "lastShownTime": 1754059296016
-  }
+  },
+  "skipDangerousModePermissionPrompt": true
 }

--- a/skills/excalidraw/REFERENCE.md
+++ b/skills/excalidraw/REFERENCE.md
@@ -1,0 +1,164 @@
+# Excalidraw Skill Reference
+
+How to feed `scripts/render.js` to produce diagrams that look like Francesco's existing ones.
+
+## CLI
+
+```
+node ~/.claude/skills/excalidraw/scripts/render.js --skeleton <input.json> --out <output.excalidraw>
+```
+
+Zero npm dependencies. Just Node.
+
+## Skeleton input format
+
+```jsonc
+[
+  {
+    "type": "rectangle",
+    "id": "auth",                    // referenced by arrows; auto-generated if omitted
+    "x": 50, "y": 100,
+    "width": 200, "height": 90,
+    "role": "core",                  // → fills backgroundColor from palette
+    "label": { "text": "AuthService\n(token verify)", "fontSize": 18 }
+  },
+  {
+    "type": "rectangle",
+    "id": "api",
+    "x": 350, "y": 100, "width": 200, "height": 90,
+    "role": "entry-point",
+    "label": { "text": "POST /login" }
+  },
+  {
+    "type": "arrow",
+    "start": { "id": "api" },
+    "end":   { "id": "auth" },
+    "label": { "text": "verifies\ntoken" }
+  }
+]
+```
+
+Notes:
+- Arrows that reference shape ids skip all coord math — `render.js` computes points + populates `startBinding` / `endBinding` / `boundElements`.
+- Multi-line labels use `\n`.
+- For `text` elements (free-floating titles), pass `width`/`height` explicitly or let `render.js` measure them.
+- For grouping, set `groupIds: ["layer-presentation"]` on every member rectangle and add a wrapping `{type:"rectangle", role:"group", groupIds:["layer-presentation"], label:{text:"Presentation"}}` outline behind them.
+- Supported types: `rectangle`, `ellipse`, `diamond`, `text`, `arrow`, `line`.
+
+## Visual style baked into render.js
+
+- `roughness: 1`, `fontFamily: 1` (Virgil), `strokeWidth: 2`, `strokeColor: "#1e1e1e"`
+- `fillStyle`: `solid` when a `backgroundColor` or `role` is set, otherwise `hachure`
+- Rectangles get `roundness: { type: 3 }`; arrows/lines `{ type: 2 }`
+
+## Role-to-color palette
+
+When you write a skeleton element with a `role` field, `render.js` fills in the matching `backgroundColor` automatically. Override per-element with an explicit `backgroundColor` if needed.
+
+| Role | Color | Use for |
+|---|---|---|
+| `entry-point` | `#a5d8ff` | HTTP routes, CLI commands, cron, event handlers, public library exports |
+| `core` / `business` | `#b2f2bb` | Domain logic modules, services |
+| `data` / `persistence` | `#ffc9c9` | Repositories, DAOs, schemas, DB clients |
+| `infra` / `config` | `#fab005` | DI wiring, startup, env loaders, feature flags |
+| `external` / `integration` | `#ced4da` | Third-party APIs, message queues, S3, Redis |
+| `cross-cutting` | `#7950f288` | Auth, logging, metrics, error handling |
+| `group` | `transparent` | Grouping containers (just an outline) |
+
+## Layout patterns per diagram type
+
+Default sizes: rectangle `200×90`, ellipse `180×80`, gap_x `80`, gap_y `120`.
+
+### `system-map.excalidraw` — layered
+
+Rows by role, top to bottom:
+
+```
+row 0 (y=  60):  entry-points          ← role: "entry-point"
+row 1 (y= 240):  core / business       ← role: "core"
+row 2 (y= 420):  data / persistence    ← role: "data"
+row 3 (y= 600):  infra / config        ← role: "infra"
+right column:    cross-cutting band    ← role: "cross-cutting"  (x= row_width + 100)
+```
+
+Wrap each row in a transparent `role: "group"` rectangle with a row title. Edges flow downward by default. If a node has `score > 4` (high centrality), upsize to `260×110`.
+
+### `entry-points.excalidraw` — two columns
+
+Left column (x=60): triggers (HTTP/CLI/event), `role: "entry-point"`. Right column (x=520): the module each one dispatches into. One arrow per row. Add a free-floating `text` title at the top: "Entry points → Core modules".
+
+### `call-graph.excalidraw` — module clusters
+
+For each top-level module from the Map agent, emit a `role: "group"` rectangle (size based on member count, ~`(members × 220)+40` wide × `~140` tall) at a position computed by ranking modules in topological order along x. Place member rectangles inside (`role` per member). Use the same `groupIds: ["mod-<name>"]` on every member. Edges only between modules — drop intra-module edges.
+
+### `data-flow.excalidraw` — types and the modules that touch them
+
+Types are `type: "ellipse"`, `role: "data"`, `180×80`, top row. Modules are rectangles, `role` per module, second row. Edge labels are exactly `reads`, `writes`, or `transforms`. Free-floating title at top.
+
+### `integrations.excalidraw` — perimeter map
+
+Central app group on the left (transparent `role: "group"` rectangle wrapping all internal modules that touch externals). External systems as a column on the right, `role: "external"`. One arrow per external link, labeled with the protocol/operation (`HTTPS`, `gRPC`, `S3 PutObject`, `pub/sub`, etc.).
+
+## Centrality cap
+
+Each diagram is capped at ~30 rectangles. Compute `score = in_degree + out_degree` per node. Keep the top-N; group the rest into a single transparent "+ K supporting modules" rectangle off to the side, with `groupIds: ["tail"]`.
+
+## Exemplars distilled from Francesco's existing diagrams
+
+### Exemplar A — high-level architecture
+
+Pattern from `tomoro-ai/docs/high-level-architecture.excalidraw`: layered, translucent-bg perimeter group, dark anchor headers, rectangles ~200×90 for modules.
+
+```jsonc
+[
+  { "type": "rectangle", "id": "edge",  "x":  20, "y":  20, "width": 700, "height": 110, "role": "group",
+    "label": { "text": "Edge",  "fontSize": 22 } },
+  { "type": "rectangle", "id": "cdn",   "x":  60, "y":  60, "width": 200, "height": 60, "role": "entry-point",
+    "label": { "text": "CloudFront" } },
+  { "type": "rectangle", "id": "wafr",  "x": 290, "y":  60, "width": 200, "height": 60, "role": "cross-cutting",
+    "label": { "text": "WAF\nrules" } },
+  { "type": "rectangle", "id": "logs",  "x": 520, "y":  60, "width": 180, "height": 60, "role": "data",
+    "label": { "text": "Access logs" } },
+
+  { "type": "rectangle", "id": "app",   "x":  20, "y": 180, "width": 700, "height": 200, "role": "group",
+    "label": { "text": "Application", "fontSize": 22 } },
+  { "type": "rectangle", "id": "api",   "x":  60, "y": 230, "width": 200, "height": 90, "role": "core",
+    "label": { "text": "API\nrouter" } },
+  { "type": "rectangle", "id": "use",   "x": 290, "y": 230, "width": 200, "height": 90, "role": "core",
+    "label": { "text": "Use cases" } },
+  { "type": "rectangle", "id": "repo",  "x": 520, "y": 230, "width": 180, "height": 90, "role": "data",
+    "label": { "text": "Repo (PG)" } },
+
+  { "type": "arrow", "start": { "id": "cdn" }, "end": { "id": "api" } },
+  { "type": "arrow", "start": { "id": "api" }, "end": { "id": "use" } },
+  { "type": "arrow", "start": { "id": "use" }, "end": { "id": "repo" }, "label": { "text": "writes" } }
+]
+```
+
+### Exemplar B — flow with annotations
+
+Pattern from `aws-api-gateway-mtls/diagrams/lambdas-business-logic.excalidraw`: bullet-list multi-line text inside boxes, occasional emoji.
+
+```jsonc
+[
+  { "type": "rectangle", "id": "ca",
+    "x":  60, "y":  60, "width": 280, "height": 160, "role": "infra",
+    "label": { "text": "Root CA\n— create private key\n— self-sign cert\n— valid 10 years" } },
+  { "type": "rectangle", "id": "ica",
+    "x": 420, "y":  60, "width": 280, "height": 160, "role": "infra",
+    "label": { "text": "Intermediate CA\n— generate CSR\n— signed by Root CA\n— valid 5 years" } },
+  { "type": "rectangle", "id": "client",
+    "x": 240, "y": 280, "width": 280, "height": 160, "role": "external",
+    "label": { "text": "🔐 Client cert\n— generated CSR\n— signed by Intermediate" } },
+
+  { "type": "arrow", "start": { "id": "ca" },     "end": { "id": "ica" },    "label": { "text": "signs" } },
+  { "type": "arrow", "start": { "id": "ica" },    "end": { "id": "client" }, "label": { "text": "issues" } }
+]
+```
+
+## Common gotchas
+
+- **Don't put text *inside* a rectangle as a separate `text` element with the same coords.** Use the rectangle's `label` field — the converter handles bound-text positioning and adds the bidirectional `boundElements` ↔ `containerId` link automatically.
+- **Arrow ids in `start`/`end` must match shape ids in the same input file.** Unresolved ids are silently dropped and the arrow falls back to absolute coords.
+- **`groupIds` must be identical across all members of a group.** A typo creates a phantom group.
+- **Why no Mermaid path?** The upstream `mermaid-to-excalidraw` library depends on `mermaid`, which calls SVG `getBBox` to compute layout. `getBBox` is not implemented by jsdom — only by real browser engines (puppeteer/playwright). Skipped to keep this skill dependency-free.

--- a/skills/excalidraw/SKILL.md
+++ b/skills/excalidraw/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: excalidraw
+description: Map a codebase by fanning out 5 parallel Explore sub-agents (topology, entry-points, call-graph, data-flow, integrations), then emit 4–5 detailed Excalidraw diagrams to docs/diagrams/. Use when the user asks to map the codebase and produce a diagram, explore the codebase and map its logic to a diagram, or visualize how the core modules and core logic are wired together.
+---
+
+# /excalidraw
+
+Produces 4–5 `.excalidraw` files under `<repo-root>/docs/diagrams/` that describe how the current codebase is structured: module topology, entry points, cross-module call graph, data flow, and external integrations.
+
+Read [REFERENCE.md](REFERENCE.md) before generating skeleton inputs — it contains the role-to-color palette, the skeleton schema, layout patterns per diagram type, and two exemplars distilled from Francesco's existing diagrams.
+
+## Pipeline
+
+### 1. Pre-flight
+
+Resolve the project root: `git rev-parse --show-toplevel 2>/dev/null || pwd`. All output paths are relative to this. Auto-create `<root>/docs/diagrams/`.
+
+Verify `node` is available: `command -v node`. If missing, stop with: `Install Node.js first.` The renderer has zero npm dependencies — no install step required.
+
+### 2. Plan preamble
+
+Print a single message to the user before fanning out:
+
+> Mapping `<repo-name>`. Five Explore agents in parallel:
+> 1. **Map** — repo topology, top-level modules, configured paths
+> 2. **Entry-points** — HTTP routes, CLI commands, cron, event handlers, public exports
+> 3. **Call-graph** — cross-module function call chains
+> 4. **Data-flow** — types/schemas, persistence boundaries, mutations
+> 5. **Integrations** — external systems, env vars, third-party APIs
+>
+> Output: 4–5 `.excalidraw` files under `docs/diagrams/`.
+
+### 3. Fan out 5 Explore sub-agents in parallel
+
+Send all five `Agent` calls in a single message with `subagent_type: "Explore"`. Each prompt must:
+
+- State the project root and the auto-excludes (`.git`, `node_modules`, `dist`, `build`, `.next`, `target`, `venv`, `.venv`, `__pycache__`, lockfiles; honor `.gitignore`).
+- Define the agent's slice (one of the five below).
+- **Require the response to be a single fenced ```json block** matching this schema:
+
+```json
+{
+  "nodes": [
+    { "id": "kebab-case-id",
+      "label": "Display name (multi-line ok with \\n)",
+      "role": "entry-point|core|data|infra|external|cross-cutting",
+      "evidence_path": "src/foo/bar.ts",
+      "evidence_line": 42,
+      "notes": "optional one-liner"
+    }
+  ],
+  "edges": [
+    { "from": "kebab-case-id",
+      "to":   "kebab-case-id",
+      "kind": "calls|reads|writes|publishes|subscribes|depends-on|http|invokes",
+      "evidence": "src/foo/bar.ts:42 → src/baz/qux.ts:88"
+    }
+  ],
+  "notes": ["Free-text observations the synthesizer should know about."]
+}
+```
+
+The five agent briefs:
+
+1. **Map agent** — Walk the directory tree. Identify top-level modules (packages, apps, services, layers). Read `package.json` / `pyproject.toml` / `go.mod` / `Cargo.toml` / `tsconfig.json` paths. One node per top-level module; edges = explicit dependencies declared between them.
+
+2. **Entry-points agent** — Find every way execution enters this codebase: HTTP route definitions (Express/FastAPI/Hono/Lambda handlers/etc.), CLI entry points (`bin` in package.json, `if __name__ == "__main__"`, click/typer/cobra commands), cron/scheduled handlers, event/queue subscribers, exported public APIs (for libraries). Edges connect each entry point to the first internal module it dispatches into.
+
+3. **Call-graph agent** — For each module identified by the Map agent, find the most significant cross-module function calls. Skip intra-module calls. Aim for ~30 most-central edges. Use grep for import statements + function call sites.
+
+4. **Data-flow agent** — Identify the core domain types/schemas (TypeScript interfaces, Pydantic models, SQL tables, protobuf messages, etc.). For each, trace where it's created, transformed, and persisted. Nodes are the types and the modules that touch them; edges have `kind: reads|writes|transforms`.
+
+5. **Integrations agent** — Identify external systems the codebase talks to: databases, message queues, third-party HTTP APIs, cloud services (S3/SQS/Lambda/etc.), env-loaded secrets, observability backends. Each external system is a `role: external` node; edges connect from the internal module that touches it.
+
+If any agent returns malformed JSON, re-prompt that single agent with the schema and an example. Do not re-explore.
+
+### 4. Synthesize
+
+Merge the five reports in the main thread:
+
+- Concatenate all `nodes`, dedupe by `id` (later definitions override earlier — Map agent runs first conceptually).
+- Concatenate all `edges`, dedupe by `(from, to, kind)`.
+- Compute centrality `score = in_degree + out_degree` for each node.
+- For each diagram below, select up to **30 nodes** by descending centrality from the relevant subset; collapse the long tail into a single `+ N supporting modules` group rectangle.
+
+### 5. Render diagrams
+
+All diagrams use the skeleton input format (see REFERENCE.md). Write each diagram's skeleton JSON to `~/.claude/skills/excalidraw/scripts/.tmp/<name>.json`, then invoke `render.js`. Output goes to `<repo-root>/docs/diagrams/<name>.excalidraw`.
+
+| Diagram | Source from | Layout pattern |
+|---|---|---|
+| `system-map.excalidraw` | Map + Call-graph nodes | Layered rows: entry-points (row 0), core (row 1), data (row 2), infra (row 3). Cross-cutting in a translucent purple band on the right. |
+| `entry-points.excalidraw` | Entry-points subset | Two columns: triggers on the left, dispatched modules on the right. Arrows left-to-right. |
+| `call-graph.excalidraw` | Call-graph nodes + edges | Module-as-cluster: each Map module is a `role: group` rectangle containing its members; edges only between clusters. |
+| `data-flow.excalidraw` | Data-flow nodes + edges | Types as ellipses (`type: "ellipse"`), modules as rectangles. Arrows labeled `reads` / `writes` / `transforms`. |
+| `integrations.excalidraw` | Integrations + the modules touching them | Central app group on the left, external systems on the right. **Skip if Integrations agent returned 0 nodes.** |
+
+Use the role-to-color palette from REFERENCE.md. Default box size `200×90`, ellipse size `180×80`, horizontal gap `80`, vertical gap `120`.
+
+Run renders in parallel with multiple `Bash` calls in one message:
+
+```bash
+node ~/.claude/skills/excalidraw/scripts/render.js --skeleton .tmp/system-map.json     --out <root>/docs/diagrams/system-map.excalidraw
+node ~/.claude/skills/excalidraw/scripts/render.js --skeleton .tmp/entry-points.json   --out <root>/docs/diagrams/entry-points.excalidraw
+# etc.
+```
+
+Clean up `.tmp/` after.
+
+### 6. End-of-run summary + deep-dive offer
+
+Print one tight summary:
+
+> Wrote N diagrams to `docs/diagrams/`:
+> - `system-map.excalidraw` — 27 modules, 41 edges
+> - `entry-points.excalidraw` — 8 entry points
+> - `call-graph.excalidraw` — 30 nodes, 52 edges
+> - `data-flow.excalidraw` — 12 types across 9 modules
+> - `integrations.excalidraw` — 6 external systems
+>
+> Drag any onto excalidraw.com to view/edit.
+>
+> Want a focused diagram for a specific module? Tell me the name and I'll spawn one Explore agent and reuse the merged report.
+
+If the user requests a deep-dive, spawn **one** Explore agent scoped to that module. Reuse the merged JSON in conversation context — do not re-explore the whole repo. Render one new file: `docs/diagrams/<module>-detail.excalidraw`.
+
+## Out of scope
+
+- Auto-commit / PR creation
+- Watch mode / regen on save
+- Cross-run caching of agent JSON
+- Generating a `README.md` alongside the diagrams
+- Language-specific agent briefs (agents stay language-agnostic; project files inform them)
+- Mermaid input (the renderer is skeleton-only — Mermaid runtime requires a real browser engine for SVG layout)

--- a/skills/excalidraw/scripts/.gitignore
+++ b/skills/excalidraw/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/skills/excalidraw/scripts/package.json
+++ b/skills/excalidraw/scripts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "excalidraw-render",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "CLI helper for the /excalidraw skill: emits .excalidraw files from Mermaid or skeleton-JSON inputs.",
+  "bin": {
+    "excalidraw-render": "render.js"
+  },
+  "scripts": {
+    "start": "node render.js"
+  },
+  "dependencies": {},
+  "packageManager": "pnpm@9.0.0"
+}

--- a/skills/excalidraw/scripts/render.js
+++ b/skills/excalidraw/scripts/render.js
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+// excalidraw-render: emit .excalidraw files from skeleton-JSON inputs.
+// Usage:
+//   node render.js --skeleton <input.json> --out <output.excalidraw>
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { randomBytes } from "node:crypto";
+
+const STYLE = {
+	roughness: 1,
+	fontFamily: 1,
+	strokeWidth: 2,
+	strokeColor: "#1e1e1e",
+	bgDefault: "transparent",
+	fillStyle: "solid",
+	fontSize: 20,
+};
+
+const ROLE_BG = {
+	"entry-point": "#a5d8ff",
+	core: "#b2f2bb",
+	business: "#b2f2bb",
+	data: "#ffc9c9",
+	persistence: "#ffc9c9",
+	infra: "#fab005",
+	config: "#fab005",
+	external: "#ced4da",
+	integration: "#ced4da",
+	"cross-cutting": "#7950f288",
+	group: "transparent",
+};
+
+const argv = parseArgs(process.argv.slice(2));
+if (!argv.out) die("missing --out <file.excalidraw>");
+if (!argv.skeleton) die("need --skeleton <file.json>");
+
+const elements = fromSkeleton(
+	JSON.parse(readFileSync(resolve(argv.skeleton), "utf8")),
+);
+
+const file = {
+	type: "excalidraw",
+	version: 2,
+	source: "https://excalidraw.com",
+	elements,
+	appState: { gridSize: null, viewBackgroundColor: "#ffffff" },
+	files: {},
+};
+
+writeFileSync(resolve(argv.out), JSON.stringify(file, null, 2));
+console.log(`wrote ${argv.out} (${elements.length} elements)`);
+
+// ---------- skeleton path ----------
+// Accepts ExcalidrawElementSkeleton-shaped objects:
+//   {type:"rectangle", id?, x, y, width, height, label?:{text,fontSize?}, role?, backgroundColor?}
+//   {type:"ellipse"|"diamond", ...}
+//   {type:"text", x, y, text, fontSize?, width?, height?}
+//   {type:"arrow", x?, y?, start:{id}|{x,y}, end:{id}|{x,y}, label?:{text}, points?}
+//   {type:"line",  x?, y?, start:{...}, end:{...}, points?}
+
+function fromSkeleton(skeleton) {
+	const out = [];
+	const byId = new Map();
+
+	// Pass 1: shapes + their bound text labels.
+	for (const el of skeleton) {
+		if (
+			el.type === "rectangle" ||
+			el.type === "ellipse" ||
+			el.type === "diamond"
+		) {
+			const id = el.id || newId();
+			const shape = baseElement({
+				...el,
+				id,
+				type: el.type,
+				backgroundColor:
+					el.backgroundColor || ROLE_BG[el.role] || STYLE.bgDefault,
+				fillStyle:
+					el.fillStyle || (el.backgroundColor || el.role ? "solid" : "hachure"),
+			});
+			shape.boundElements = [];
+			out.push(shape);
+			byId.set(id, shape);
+
+			if (el.label?.text) {
+				const labelId = newId();
+				const label = baseElement({
+					id: labelId,
+					type: "text",
+					x: shape.x + shape.width / 2,
+					y: shape.y + shape.height / 2,
+					width: 0,
+					height: 0,
+					backgroundColor: "transparent",
+					fillStyle: "solid",
+					strokeWidth: 1,
+				});
+				label.text = el.label.text;
+				label.originalText = el.label.text;
+				label.fontSize = el.label.fontSize || STYLE.fontSize;
+				label.fontFamily = el.label.fontFamily || STYLE.fontFamily;
+				label.textAlign = "center";
+				label.verticalAlign = "middle";
+				label.containerId = id;
+				label.lineHeight = 1.25;
+				const measured = measureText(label.text, label.fontSize);
+				label.width = measured.width;
+				label.height = measured.height;
+				label.x = shape.x + (shape.width - measured.width) / 2;
+				label.y = shape.y + (shape.height - measured.height) / 2;
+				label.baseline = Math.round(label.fontSize * 0.85);
+				shape.boundElements.push({ id: labelId, type: "text" });
+				out.push(label);
+				byId.set(labelId, label);
+			}
+		} else if (el.type === "text") {
+			const id = el.id || newId();
+			const fontSize = el.fontSize || STYLE.fontSize;
+			const measured =
+				el.width && el.height
+					? { width: el.width, height: el.height }
+					: measureText(el.text, fontSize);
+			const text = baseElement({
+				...el,
+				id,
+				type: "text",
+				width: measured.width,
+				height: measured.height,
+				backgroundColor: "transparent",
+				fillStyle: "solid",
+				strokeWidth: 1,
+			});
+			text.text = el.text;
+			text.originalText = el.text;
+			text.fontSize = fontSize;
+			text.fontFamily = el.fontFamily || STYLE.fontFamily;
+			text.textAlign = el.textAlign || "left";
+			text.verticalAlign = el.verticalAlign || "top";
+			text.lineHeight = 1.25;
+			text.baseline = Math.round(fontSize * 0.85);
+			out.push(text);
+			byId.set(id, text);
+		}
+	}
+
+	// Pass 2: arrows + lines (need shape ids resolved).
+	for (const el of skeleton) {
+		if (el.type !== "arrow" && el.type !== "line") continue;
+
+		const id = el.id || newId();
+		const startBinding = bindingFor(el.start, byId);
+		const endBinding = bindingFor(el.end, byId);
+		const points = computePoints(el, startBinding, endBinding, byId);
+		const start = points[0];
+		const end = points[points.length - 1];
+
+		const arrow = baseElement({
+			...el,
+			id,
+			type: el.type,
+			x: 0, // arrow x/y is anchor; points are relative
+			y: 0,
+			width: Math.abs(end[0] - start[0]),
+			height: Math.abs(end[1] - start[1]),
+			backgroundColor: "transparent",
+			fillStyle: "solid",
+		});
+		arrow.x = start[0] === 0 ? 0 : (el.x ?? start[0]);
+		arrow.y = start[1] === 0 ? 0 : (el.y ?? start[1]);
+		// Re-anchor points relative to arrow.x/y
+		arrow.points = points.map(([px, py]) => [px - arrow.x, py - arrow.y]);
+		arrow.lastCommittedPoint = null;
+		arrow.startBinding = startBinding;
+		arrow.endBinding = endBinding;
+		arrow.startArrowhead = null;
+		arrow.endArrowhead = el.type === "arrow" ? "arrow" : null;
+		arrow.elbowed = false;
+		out.push(arrow);
+
+		// Wire boundElements on the connected shapes
+		if (startBinding)
+			addBound(byId.get(startBinding.elementId), { id, type: el.type });
+		if (endBinding)
+			addBound(byId.get(endBinding.elementId), { id, type: el.type });
+
+		if (el.label?.text) {
+			const labelId = newId();
+			const fontSize = el.label.fontSize || 16;
+			const mid = midpoint(points);
+			const measured = measureText(el.label.text, fontSize);
+			const label = baseElement({
+				id: labelId,
+				type: "text",
+				x: mid[0] - measured.width / 2,
+				y: mid[1] - measured.height / 2,
+				width: measured.width,
+				height: measured.height,
+				backgroundColor: "transparent",
+				fillStyle: "solid",
+				strokeWidth: 1,
+			});
+			label.text = el.label.text;
+			label.originalText = el.label.text;
+			label.fontSize = fontSize;
+			label.fontFamily = STYLE.fontFamily;
+			label.textAlign = "center";
+			label.verticalAlign = "middle";
+			label.containerId = id;
+			label.lineHeight = 1.25;
+			label.baseline = Math.round(fontSize * 0.85);
+			arrow.boundElements = [{ id: labelId, type: "text" }];
+			out.push(label);
+		}
+	}
+
+	return out;
+}
+
+function bindingFor(end, byId) {
+	if (!end || !end.id) return null;
+	const target = byId.get(end.id);
+	if (!target) return null;
+	return { elementId: end.id, focus: 0, gap: 4 };
+}
+
+function computePoints(el, startBinding, endBinding, byId) {
+	if (Array.isArray(el.points) && el.points.length >= 2) return el.points;
+
+	let sx, sy, ex, ey;
+	if (startBinding) {
+		const s = byId.get(startBinding.elementId);
+		sx = s.x + s.width / 2;
+		sy = s.y + s.height / 2;
+	} else if (el.start && Number.isFinite(el.start.x)) {
+		sx = el.start.x;
+		sy = el.start.y;
+	} else {
+		sx = el.x ?? 0;
+		sy = el.y ?? 0;
+	}
+	if (endBinding) {
+		const e = byId.get(endBinding.elementId);
+		ex = e.x + e.width / 2;
+		ey = e.y + e.height / 2;
+	} else if (el.end && Number.isFinite(el.end.x)) {
+		ex = el.end.x;
+		ey = el.end.y;
+	} else {
+		ex = (el.x ?? 0) + 100;
+		ey = el.y ?? 0;
+	}
+	return [
+		[sx, sy],
+		[ex, ey],
+	];
+}
+
+function midpoint(points) {
+	if (points.length === 2) {
+		return [
+			(points[0][0] + points[1][0]) / 2,
+			(points[0][1] + points[1][1]) / 2,
+		];
+	}
+	return points[Math.floor(points.length / 2)];
+}
+
+function addBound(el, ref) {
+	if (!el) return;
+	el.boundElements = el.boundElements || [];
+	if (!el.boundElements.find((b) => b.id === ref.id))
+		el.boundElements.push(ref);
+}
+
+// ---------- element envelope ----------
+
+function baseElement(el) {
+	return {
+		id: el.id || newId(),
+		type: el.type,
+		x: el.x ?? 0,
+		y: el.y ?? 0,
+		width: el.width ?? 0,
+		height: el.height ?? 0,
+		angle: 0,
+		strokeColor: el.strokeColor || STYLE.strokeColor,
+		backgroundColor: el.backgroundColor ?? STYLE.bgDefault,
+		fillStyle: el.fillStyle || STYLE.fillStyle,
+		strokeWidth: el.strokeWidth ?? STYLE.strokeWidth,
+		strokeStyle: el.strokeStyle || "solid",
+		roughness: el.roughness ?? STYLE.roughness,
+		opacity: el.opacity ?? 100,
+		groupIds: el.groupIds || [],
+		frameId: null,
+		roundness:
+			el.type === "rectangle"
+				? { type: 3 }
+				: el.type === "arrow" || el.type === "line"
+					? { type: 2 }
+					: null,
+		seed: rint(),
+		version: 1,
+		versionNonce: rint(),
+		isDeleted: false,
+		boundElements: el.boundElements || [],
+		updated: Date.now(),
+		link: null,
+		locked: false,
+	};
+}
+
+function measureText(text, fontSize) {
+	const lines = String(text).split("\n");
+	const longest = lines.reduce((m, l) => Math.max(m, l.length), 0);
+	// Rough heuristic: ~0.55em per char width for Virgil at fontSize.
+	const width = Math.max(40, Math.ceil(longest * fontSize * 0.55));
+	const height = Math.ceil(lines.length * fontSize * 1.25);
+	return { width, height };
+}
+
+function newId() {
+	return randomBytes(12).toString("base64url");
+}
+
+function rint() {
+	return Math.floor(Math.random() * 2_000_000_000);
+}
+
+function parseArgs(args) {
+	const out = {};
+	for (let i = 0; i < args.length; i++) {
+		const a = args[i];
+		if (a.startsWith("--")) {
+			const key = a.slice(2);
+			const val =
+				args[i + 1] && !args[i + 1].startsWith("--") ? args[++i] : true;
+			out[key] = val;
+		}
+	}
+	return out;
+}
+
+function die(msg) {
+	console.error(`render.js: ${msg}`);
+	process.exit(1);
+}

--- a/skills/ralph-bootstrap/SKILL.md
+++ b/skills/ralph-bootstrap/SKILL.md
@@ -29,13 +29,14 @@ Pass the chosen backend as the first argument:
 ~/.claude/skills/ralph-bootstrap/scripts/bootstrap.sh beads
 ```
 
-This creates `scripts/ralph/prompt.md` containing the tracker-specific instructions (with a `<!-- tracker: github -->` or `<!-- tracker: beads -->` marker on the first line so the ralph scripts can detect the backend).
+This creates `scripts/ralph/prompt.md` containing the tracker-specific instructions (with a `<!-- tracker: github -->` or `<!-- tracker: beads -->` marker on the first line so the ralph scripts can detect the backend), plus `scripts/ralph/notify.env.example` for WhatsApp notifications.
 
 ## Files Created
 
 ```
 scripts/ralph/
-└── prompt.md # Instructions for Claude (tracker-specific)
+├── prompt.md            # Instructions for Claude (tracker-specific)
+└── notify.env.example   # WhatsApp notify template (copy to notify.env to enable AFK pings)
 ```
 
 ## Usage After Bootstrap

--- a/skills/ralph-bootstrap/scripts/bootstrap.sh
+++ b/skills/ralph-bootstrap/scripts/bootstrap.sh
@@ -29,10 +29,18 @@ fi
 mkdir -p "$TARGET_DIR"
 cp "$SOURCE_FILE" "$TARGET_DIR/prompt.md"
 
+NOTIFY_EXAMPLE="$TEMPLATE_DIR/notify.env.example"
+if [ -f "$NOTIFY_EXAMPLE" ] && [ ! -f "$TARGET_DIR/notify.env.example" ]; then
+    cp "$NOTIFY_EXAMPLE" "$TARGET_DIR/notify.env.example"
+fi
+
 echo "Ralph template ($BACKEND) copied to $TARGET_DIR/prompt.md"
 echo ""
 echo "Files created:"
 echo "  - $TARGET_DIR/prompt.md (Claude instructions, tracker=$BACKEND)"
+echo "  - $TARGET_DIR/notify.env.example (WhatsApp notify template; copy to notify.env to enable)"
+echo ""
+echo "Tip: copy notify.env.example -> notify.env and fill in CallMeBot creds to get WhatsApp pings when AFK runs finish."
 echo ""
 echo "Next steps:"
 echo "  1. Run: ralph-once (single iteration)"


### PR DESCRIPTION
## Summary

- Add `excalidraw` skill: maps codebases via 5 parallel sub-agents and emits Excalidraw diagrams to `docs/diagrams/`
- Add `notify.env.example` to ralph-bootstrap so WhatsApp AFK ping template ships out of the box
- Update `settings.json` (beads marketplace, advisorModel, viewMode, cleanupPeriodDays, skipDangerousModePermissionPrompt) and clean up `CLAUDE.md` instructions

## Test plan

- [ ] Run `/excalidraw` in a project and verify diagrams generated in `docs/diagrams/`
- [ ] Run ralph-bootstrap and confirm `scripts/ralph/notify.env.example` is created
- [ ] Verify new settings take effect (beads plugin loads, verbose view, cleanup period)

🤖 Generated with [Claude Code](https://claude.com/claude-code)