### PR TITLE
feat: extract pragmatic-programmer rules, add skill + quality-gate step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,16 +29,4 @@ You can use the following agents:
 
 ## Pragmatic programmer
 
-Always follow these rules, fundamental pillars of software engineering:
-
-- orthogonality: reduce interdependency among the system’s components. Keep you code decoupled, avoid global data, avoid similar functions
-- Test state coverage , not code coverage
-- Make it easy to reuse
-- Design components that are self-contained, independent and with a single well defined purpose
-- Plan for change
-- Don’t assume it, prove it . Prove your assumptions in the actual environment
-- Crash early
-- Minimise coupling between modules
-- Design to test
-- Don’t use code you don’t understand
-- Invest in the abstraction , not the implementation
+Always follow the fundamental pillars of software engineering documented in `rules/general/pragmatic-programmer.md`.

--- a/commands/quality-gate.md
+++ b/commands/quality-gate.md
@@ -32,12 +32,17 @@ Use the Task tool with `subagent_type: "code-quality-verifier"` passing:
 
 **When no spec (no spec mode):** pass the full commit history as context. Instruct the agent to audit against commit intent — verify that the code changes match what the commits describe, and flag any discrepancies.
 
-## 4. Report Findings
+## 4. Pragmatic Programmer Check
+
+After the verifier agent returns, run `/pragmatic-programmer-check` on the same diff and include its findings in the final report under a dedicated "Pragmatic Programmer" section. Treat any FAIL from that check as a blocking issue in the quality gate.
+
+## 5. Report Findings
 
 Present the agent's findings directly in the terminal. Do not write any output files. Include the full verification summary with:
 - Spec Compliance status (omit if no spec — replace with Commit Intent Alignment)
 - Security assessment
 - Test quality assessment
 - Architecture alignment
+- Pragmatic Programmer check results (from step 4)
 - All issues with severity levels and file:line references
 - Required actions

--- a/rules/general/pragmatic-programmer.md
+++ b/rules/general/pragmatic-programmer.md
@@ -1,0 +1,26 @@
+# Pragmatic Programmer
+
+Universal engineering principles that apply to every project, stack, and language. Follow them at all times.
+
+## Decoupling
+
+- **Orthogonality** — reduce interdependency among components. Keep code decoupled, avoid global data, avoid similar functions.
+- **Minimise coupling between modules** — a change in one place should not ripple through unrelated code.
+- **Design components that are self-contained, independent, and with a single well-defined purpose.**
+
+## Change & Reuse
+
+- **Plan for change**
+- **Make it easy to reuse**
+- **Invest in the abstraction, not the implementation** — abstractions outlive any single implementation.
+
+## Correctness
+
+- **Don't assume it, prove it** — verify assumptions in the actual environment
+- **Crash early** — fail fast and loudly when an invariant breaks
+- **Don't use code you don't understand**
+
+## Testing
+
+- **Test state coverage, not code coverage**
+- **Design to test**

--- a/skills/pragmatic-programmer-check/SKILL.md
+++ b/skills/pragmatic-programmer-check/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: pragmatic-programmer-check
+description: Audit a code change against the Pragmatic Programmer principles (orthogonality, coupling, testability, crash-early, prove-don't-assume, abstraction-over-implementation). Use when user wants to check code against pragmatic-programmer rules, or as part of a quality gate review.
+---
+
+# Pragmatic Programmer Check
+
+Audit the current change against the universal engineering rules in [../../rules/general/pragmatic-programmer.md](../../rules/general/pragmatic-programmer.md). Produce a concise report
+
+## 1. Gather the diff
+
+Run `git diff main...HEAD` (fallback `master...HEAD`, then `HEAD~5...HEAD`). If the user passed a path or PR number as `$ARGUMENTS`, scope to that instead.
+
+## 2. Score each principle
+
+For every principle below, decide **PASS / WARN / FAIL** and cite `file:line` evidence when WARN/FAIL.
+
+| # | Principle | What to look for |
+|---|-----------|------------------|
+| 1 | Orthogonality | Cross-module reach-ins, shared mutable globals, near-duplicate functions |
+| 2 | Minimise coupling | New imports across layer boundaries, modules that know too much about each other |
+| 3 | Self-contained components | Single responsibility per unit; no god-files, no grab-bag utils |
+| 4 | Plan for change | Magic numbers, hard-coded config, decisions that will be painful to reverse |
+| 5 | Make it easy to reuse | Code that is copy-paste-ready vs locked to one call site |
+| 6 | Invest in the abstraction | Leaky abstractions, abstractions that expose implementation details |
+| 7 | Don't assume it, prove it | Untested assumptions, missing integration check, "should work" comments |
+| 8 | Crash early | Silent catches, fallback defaults that hide bugs, swallowed errors |
+| 9 | Don't use code you don't understand | Copy-pasted snippets, unexplained magic, unfamiliar libraries pulled in without rationale |
+| 10 | Test state coverage, not code coverage | Tests that hit lines without asserting meaningful state transitions |
+| 11 | Design to test | Hard-to-test code: hidden dependencies, time/IO not injected, untestable side effects |
+
+## 3. Report
+
+Output exactly this structure — nothing else:
+
+```
+# Pragmatic Programmer Check
+
+## Summary
+<one line: overall verdict + count of FAIL / WARN>
+
+## Findings
+<for each WARN/FAIL>
+- [SEVERITY] <principle> — <file:line> — <one sentence: what's wrong + suggested fix>
+
+## Passes
+<one line listing principle numbers that passed cleanly>
+```
+
+If everything passes, say so in one line and stop. Do not pad.


### PR DESCRIPTION
## Summary
- Extracted inline pragmatic-programmer principles from `CLAUDE.md` into `rules/general/pragmatic-programmer.md`, grouped by theme (Decoupling / Change & Reuse / Correctness / Testing)
- Added `skills/pragmatic-programmer-check/SKILL.md` — a new `/pragmatic-programmer-check` skill that audits a diff and emits a PASS/WARN/FAIL report
- Wired `/pragmatic-programmer-check` into `commands/quality-gate.md` as a blocking step (FAILs block merge)

## Test plan
- [ ] Run `/pragmatic-programmer-check` against a sample diff and verify PASS/WARN/FAIL output
- [ ] Run `/quality-gate` and confirm the pragmatic-programmer-check step appears and runs
- [ ] Confirm `CLAUDE.md` no longer contains the inline PP block and instead points to the rules file
- [ ] Verify `.last-cleanup` was not included in the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quality gate pipeline now includes a Pragmatic Programmer Check step to validate code against core engineering principles. Failures in this check are treated as blocking.

* **Documentation**
  * Added pragmatic programming guidelines covering decoupling, change management, correctness, and testing practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francesco-albanese/claude-code-config/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->