### PR TITLE
chore: gitignore runtime artifacts + settings cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,13 @@ sessions/
 tasks/
 teams/
 
+# Daemon/jobs runtime state
+daemon/
+daemon.log
+jobs/
+.last-cleanup
+.last-update-result.json
+
 # macOS
 .DS_Store
 

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,6 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 9999,
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "MAX_THINKING_TOKENS": "128000",
     "CLAUDE_CODE_EFFORT_LEVEL": "xhigh",
@@ -136,7 +135,8 @@
     "pyright-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
-    "beads@beads-marketplace": true
+    "beads@beads-marketplace": true,
+    "specwright@specwright": true
   },
   "extraKnownMarketplaces": {
     "beads-marketplace": {
@@ -147,21 +147,6 @@
     }
   },
   "viewMode": "verbose",
-  "sandbox": {
-    "enabled": true,
-    "autoAllowBashIfSandboxed": true,
-    "network": {
-      "allowUnixSockets": [
-        "/var/run/docker.sock"
-      ],
-      "allowLocalBinding": true
-    },
-    "excludedCommands": [
-      "docker:*",
-      "gh:*",
-      "git:*"
-    ]
-  },
   "advisorModel": "opus",
   "showClearContextOnPlanAccept": true,
   "skipDangerousModePermissionPrompt": true,


### PR DESCRIPTION
## Summary

- **`.gitignore`**: added "Daemon/jobs runtime state" section ignoring `daemon/`, `daemon.log`, `jobs/`, `.last-cleanup`, `.last-update-result.json`
- **`settings.json`**: removed `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env flag (experimental, no longer needed)
- **`settings.json`**: removed entire `sandbox` block — security-relevant change; sandbox restrictions have been lifted from the harness config
- **`settings.json`**: added `specwright@specwright` enabled plugin

## Test plan

- [ ] Confirm runtime artifacts (`daemon/`, `jobs/`, etc.) are no longer tracked by git
- [ ] Confirm Claude Code starts without the experimental agent-teams flag
- [ ] Confirm sandbox removal does not regress any required tooling constraints
- [ ] Confirm specwright plugin loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment to exclude additional daemon and job runtime artifacts
  * Enabled two new plugins to support additional features and integrations
  * Cleaned up deprecated configuration settings for simplified maintenance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->