### PR TITLE
Use autoCompactWindow setting instead of env var

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 9999,
+  "autoCompactWindow": 180000,
   "env": {
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "MAX_THINKING_TOKENS": "128000",
-    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh",
-    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "180000"
+    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## Summary
Sets the auto-compact token threshold using the documented `autoCompactWindow` setting (180,000) instead of the undocumented `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var added in #55.

## Why
Using the real settings field instead of an env-var workaround is clearer and supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the auto-compaction setting to use a new top-level configuration value.
  * Removed the older environment-based setting and kept the compaction window set to 180000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->